### PR TITLE
Fix linode ddns script

### DIFF
--- a/linode.php
+++ b/linode.php
@@ -11,7 +11,7 @@ $pwd = (string)$argv[2];
 $hostname = (string)$argv[3];
 $ip = (string)$argv[4];
 
-$API_TOKEN = $account;
+$API_TOKEN = $pwd;
 
 // check the hostname contains '.'
 if (strpos($hostname, '.') === false) {
@@ -27,13 +27,13 @@ if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
 
 $hostname = explode('.', $hostname);
 $arrayCount = count($hostname);
-if ($arrayCount > 2) {
-    $subDomain = implode('.', array_slice($hostname, 0, $arrayCount-2));
-    $domain = implode('.', array_slice($hostname, $arrayCount-2, 2));
-} else {
-    $subDomain = '@';
-    $domain = implode('.', $hostname);
+if ($arrayCount < 2) {
+	echo 'badparam';
+	exit();
 }
+
+$subDomain = $hostname[0];
+$domain = implode('.', array_slice($hostname, 1, $arrayCount-1));
 
 $post = array(
     'api_key'=>$account,


### PR DESCRIPTION
- Use password rather than account as the API token so that it isn't visible in the API (and also to meet my expectation). Username is ignored.
- Split hostname into "foo.bar.biff.blat" into "foo" and "bar.biff.blat" so that it copes with deeper than two domains